### PR TITLE
Feature 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/slider": "^5.0.1",
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.17",
         "expo": "54.0.7",
         "expo-file-system": "~19.0.14",
+        "expo-image-picker": "^17.0.8",
         "expo-notifications": "^0.32.11",
         "expo-sharing": "~14.0.7",
         "expo-sqlite": "~16.0.8",
@@ -2780,6 +2782,12 @@
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
+    "node_modules/@react-native-community/slider": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.0.1.tgz",
+      "integrity": "sha512-K3JRWkIW4wQ79YJ6+BPZzp1SamoikxfPRw7Yw4B4PElEQmqZFrmH9M5LxvIo460/3QSrZF/wCgi3qizJt7g/iw==",
+      "license": "MIT"
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.81.4",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.4.tgz",
@@ -4695,6 +4703,27 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.8.tgz",
+      "integrity": "sha512-489ByhVs2XPoAu9zodivAKLv7hG4S/FOe8hO/C2U6jVxmRjpAKakKNjMml0IwWjf1+c/RYBqm1XxKaZ+vq/fDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/slider": "^5.0.1",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "expo": "54.0.7",
     "expo-file-system": "~19.0.14",
+    "expo-image-picker": "^17.0.8",
     "expo-notifications": "^0.32.11",
     "expo-sharing": "~14.0.7",
     "expo-sqlite": "~16.0.8",

--- a/src/components/PreferenceSlider.tsx
+++ b/src/components/PreferenceSlider.tsx
@@ -1,13 +1,6 @@
-import React, { useRef } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  PanResponder,
-  Animated,
-  LayoutRectangle,
-  LayoutChangeEvent,
-} from 'react-native';
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Slider from '@react-native-community/slider';
 
 interface PreferenceSliderProps {
   label: string;
@@ -32,69 +25,7 @@ export const PreferenceSlider: React.FC<PreferenceSliderProps> = ({
   onBlur,
   error,
 }) => {
-  const [sliderLayout, setSliderLayout] = React.useState<LayoutRectangle | null>(null);
-  const panValue = useRef(new Animated.Value(0)).current;
-  const lastOffset = useRef(0);
-
-  React.useEffect(() => {
-    if (sliderLayout) {
-      const percentage = ((value - min) / (max - min)) * 100;
-      const newPosition = (percentage / 100) * sliderLayout.width;
-      panValue.setValue(newPosition);
-      lastOffset.current = newPosition;
-    }
-  }, [value, sliderLayout, min, max]);
-
-  const panResponder = React.useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onPanResponderGrant: () => {
-        panValue.setOffset(lastOffset.current);
-      },
-      onPanResponderMove: (_, gestureState) => {
-        if (sliderLayout) {
-          const moveValue = lastOffset.current + gestureState.dx;
-          const boundedValue = Math.min(
-            Math.max(0, moveValue),
-            sliderLayout.width
-          );
-          panValue.setValue(boundedValue - lastOffset.current);
-        }
-      },
-      onPanResponderRelease: (_, gestureState) => {
-        if (sliderLayout) {
-          const releaseValue = lastOffset.current + gestureState.dx;
-          const boundedValue = Math.min(
-            Math.max(0, releaseValue),
-            sliderLayout.width
-          );
-          lastOffset.current = boundedValue;
-          const percentage = (boundedValue / sliderLayout.width) * 100;
-          const calculatedValue = min + (percentage / 100) * (max - min);
-          const steppedValue = Math.round(calculatedValue / step) * step;
-          onValueChange(Math.max(min, Math.min(max, steppedValue)));
-          if (onBlur) onBlur();
-        }
-      },
-    })
-  ).current;
-
-  const handleLayout = (event: LayoutChangeEvent) => {
-    const layout = event.nativeEvent.layout;
-    setSliderLayout(layout);
-    const percentage = ((value - min) / (max - min)) * 100;
-    const initialPosition = (percentage / 100) * layout.width;
-    panValue.setValue(initialPosition);
-    lastOffset.current = initialPosition;
-  };
-
-  const animatedStyle = {
-    transform: [{ translateX: panValue }],
-  };
-
-  const percentage = ((value - min) / (max - min)) * 100;
-  const trackWidth = `${percentage}%`;
+  // Library slider handles visuals; we just display label/value
 
   return (
     <View style={styles.container}>
@@ -102,17 +33,19 @@ export const PreferenceSlider: React.FC<PreferenceSliderProps> = ({
         <Text style={styles.label}>{label}</Text>
         <Text style={styles.value}>{value}{unit}</Text>
       </View>
-      <View 
-        style={styles.sliderContainer}
-        onLayout={handleLayout}
-      >
-        <View style={styles.track}>
-          <View style={[styles.fill, { width: trackWidth as any }]} />
-          <Animated.View
-            style={[styles.thumb, animatedStyle]}
-            {...panResponder.panHandlers}
-          />
-        </View>
+      <View style={styles.sliderContainer}>
+        <Slider
+          style={styles.nativeSlider}
+          minimumValue={min}
+          maximumValue={max}
+          step={step}
+          value={value}
+          minimumTrackTintColor="#4285F4"
+          maximumTrackTintColor="#E5E7EB"
+          thumbTintColor="#4285F4"
+          onValueChange={(v) => onValueChange(v)}
+          onSlidingComplete={() => onBlur && onBlur()}
+        />
       </View>
       {error && <Text style={styles.errorText}>{error}</Text>}
     </View>
@@ -143,37 +76,12 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   sliderContainer: {
-    height: 20,
+    height: 40,
     justifyContent: 'center',
   },
-  track: {
-    height: 4,
-    backgroundColor: '#E5E7EB',
-    borderRadius: 2,
-    position: 'relative',
-  },
-  fill: {
-    position: 'absolute',
-    height: '100%',
-    backgroundColor: '#4285F4',
-    borderRadius: 2,
-  },
-  thumb: {
-    position: 'absolute',
-    width: 20,
-    height: 20,
-    backgroundColor: '#4285F4',
-    borderRadius: 10,
-    top: -8,
-    marginLeft: -10,
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-    elevation: 5,
+  nativeSlider: {
+    width: '100%',
+    height: 40,
   },
   errorText: {
     color: '#EF4444',

--- a/src/services/currency.ts
+++ b/src/services/currency.ts
@@ -1,0 +1,66 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'currency_settings_v1';
+
+export interface CurrencySettings {
+  currency: string; // ISO 4217 code, e.g., 'GBP', 'USD', 'EUR'
+  locale?: string; // optional BCP 47, e.g., 'en-GB'
+}
+
+const defaultSettings: CurrencySettings = { currency: 'GBP' };
+
+export async function loadCurrencySettings(): Promise<CurrencySettings> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultSettings;
+    const parsed = JSON.parse(raw);
+    return { ...defaultSettings, ...parsed } as CurrencySettings;
+  } catch {
+    return defaultSettings;
+  }
+}
+
+export async function saveCurrencySettings(settings: CurrencySettings): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {}
+}
+
+export async function formatCurrency(amount: number): Promise<string> {
+  const s = await loadCurrencySettings();
+  try {
+    return new Intl.NumberFormat(s.locale || undefined, {
+      style: 'currency',
+      currency: s.currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    // Fallback simple formatting
+    const symbol = getCurrencySymbol(s.currency);
+    return `${symbol}${Math.round(amount)}`;
+  }
+}
+
+export function getCurrencySymbol(code: string): string {
+  switch (code) {
+    case 'USD': return '$';
+    case 'EUR': return '€';
+    case 'GBP': return '£';
+    case 'JPY': return '¥';
+    default: return code + ' ';
+  }
+}
+
+export function formatWithSettings(amount: number, settings: CurrencySettings): string {
+  try {
+    return new Intl.NumberFormat(settings.locale || undefined, {
+      style: 'currency',
+      currency: settings.currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${getCurrencySymbol(settings.currency)}${Math.round(amount)}`;
+  }
+}
+
+

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -11,6 +11,7 @@ export interface Trip {
   activityLevel: number;
   groupType: string;
   interests: string; // JSON string
+  dailySpendCap?: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -26,6 +27,26 @@ export interface Activity {
   location: string;
   time: string;
   day: number;
+  receiptUri?: string | null;
+  bookingStatus?: 'placeholder' | 'booked' | 'canceled' | null;
+  bookingReminderISO?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Polls
+export interface PollOptionVote {
+  option: string;
+  score: number; // aggregated score
+}
+
+export interface Poll {
+  id: string;
+  tripId: string;
+  day: number; // target day
+  time: string; // target time HH:mm
+  options: string; // JSON array of strings
+  votes: string; // JSON map option->score
   createdAt: string;
   updatedAt: string;
 }
@@ -60,6 +81,7 @@ class DatabaseService {
         activityLevel INTEGER NOT NULL,
         groupType TEXT NOT NULL,
         interests TEXT NOT NULL,
+        dailySpendCap INTEGER,
         createdAt TEXT NOT NULL,
         updatedAt TEXT NOT NULL
       );
@@ -77,6 +99,23 @@ class DatabaseService {
         location TEXT,
         time TEXT,
         day INTEGER NOT NULL,
+        receiptUri TEXT,
+        bookingStatus TEXT,
+        bookingReminderISO TEXT,
+        createdAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL,
+        FOREIGN KEY (tripId) REFERENCES trips (id) ON DELETE CASCADE
+      );
+    `;
+
+    const createPollsTable = `
+      CREATE TABLE IF NOT EXISTS polls (
+        id TEXT PRIMARY KEY,
+        tripId TEXT NOT NULL,
+        day INTEGER NOT NULL,
+        time TEXT NOT NULL,
+        options TEXT NOT NULL,
+        votes TEXT NOT NULL,
         createdAt TEXT NOT NULL,
         updatedAt TEXT NOT NULL,
         FOREIGN KEY (tripId) REFERENCES trips (id) ON DELETE CASCADE
@@ -85,6 +124,13 @@ class DatabaseService {
 
     await this.db.execAsync(createTripsTable);
     await this.db.execAsync(createActivitiesTable);
+    await this.db.execAsync(createPollsTable);
+
+    // best-effort migrations for existing installations (ALTER TABLE will throw if column exists)
+    try { await this.db!.execAsync("ALTER TABLE trips ADD COLUMN dailySpendCap INTEGER"); } catch {}
+    try { await this.db!.execAsync("ALTER TABLE activities ADD COLUMN receiptUri TEXT"); } catch {}
+    try { await this.db!.execAsync("ALTER TABLE activities ADD COLUMN bookingStatus TEXT"); } catch {}
+    try { await this.db!.execAsync("ALTER TABLE activities ADD COLUMN bookingReminderISO TEXT"); } catch {}
   }
 
   async saveTrip(tripData: Omit<Trip, 'id' | 'createdAt' | 'updatedAt'>): Promise<string> {
@@ -101,13 +147,13 @@ class DatabaseService {
     };
 
     const insertQuery = `
-      INSERT INTO trips (id, destination, checkIn, checkOut, budget, activityLevel, groupType, interests, createdAt, updatedAt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO trips (id, destination, checkIn, checkOut, budget, activityLevel, groupType, interests, dailySpendCap, createdAt, updatedAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `;
 
     await this.db.runAsync(
       insertQuery,
-      [trip.id, trip.destination, trip.checkIn, trip.checkOut, trip.budget, trip.activityLevel, trip.groupType, trip.interests, trip.createdAt, trip.updatedAt]
+      [trip.id, trip.destination, trip.checkIn, trip.checkOut, trip.budget, trip.activityLevel, trip.groupType, trip.interests, (trip as any).dailySpendCap ?? null, trip.createdAt, trip.updatedAt]
     );
     return id;
   }
@@ -143,6 +189,7 @@ class DatabaseService {
           activityLevel = COALESCE(?, activityLevel),
           groupType = COALESCE(?, groupType),
           interests = COALESCE(?, interests),
+          dailySpendCap = COALESCE(?, dailySpendCap),
           updatedAt = ?
       WHERE id = ?
     `;
@@ -157,6 +204,7 @@ class DatabaseService {
         tripData.activityLevel || null,
         tripData.groupType || null,
         tripData.interests || null,
+        (tripData as any).dailySpendCap ?? null,
         updatedAt,
         id
       ]
@@ -195,13 +243,13 @@ class DatabaseService {
     };
 
     const insertQuery = `
-      INSERT INTO activities (id, tripId, name, type, duration, cost, description, location, time, day, createdAt, updatedAt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO activities (id, tripId, name, type, duration, cost, description, location, time, day, receiptUri, bookingStatus, bookingReminderISO, createdAt, updatedAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `;
 
     await this.db.runAsync(
       insertQuery,
-      [activity.id, activity.tripId, activity.name, activity.type, activity.duration, activity.cost, activity.description, activity.location, activity.time, activity.day, activity.createdAt, activity.updatedAt]
+      [activity.id, activity.tripId, activity.name, activity.type, activity.duration, activity.cost, activity.description, activity.location, activity.time, activity.day, (activity as any).receiptUri ?? null, (activity as any).bookingStatus ?? null, (activity as any).bookingReminderISO ?? null, activity.createdAt, activity.updatedAt]
     );
     return id;
   }
@@ -229,6 +277,9 @@ class DatabaseService {
           location = COALESCE(?, location),
           time = COALESCE(?, time),
           day = COALESCE(?, day),
+          receiptUri = COALESCE(?, receiptUri),
+          bookingStatus = COALESCE(?, bookingStatus),
+          bookingReminderISO = COALESCE(?, bookingReminderISO),
           updatedAt = ?
       WHERE id = ?
     `;
@@ -244,6 +295,9 @@ class DatabaseService {
         activityData.location || null,
         activityData.time || null,
         activityData.day || null,
+        (activityData as any).receiptUri ?? null,
+        (activityData as any).bookingStatus ?? null,
+        (activityData as any).bookingReminderISO ?? null,
         updatedAt,
         id
       ]
@@ -257,6 +311,69 @@ class DatabaseService {
     
     await this.db.runAsync(deleteQuery, [id]);
   }
+
+  // Poll CRUD
+  async savePoll(poll: Omit<Poll, 'id' | 'createdAt' | 'updatedAt'>): Promise<string> {
+    if (!this.db) throw new Error('Database not initialized');
+    const id = Date.now().toString();
+    const now = new Date().toISOString();
+    const insertQuery = `
+      INSERT INTO polls (id, tripId, day, time, options, votes, createdAt, updatedAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `;
+    await this.db.runAsync(insertQuery, [id, poll.tripId, poll.day, poll.time, poll.options, poll.votes, now, now]);
+    return id;
+  }
+
+  async updatePollVotes(id: string, votes: Record<string, number>): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+    const now = new Date().toISOString();
+    await this.db.runAsync(
+      'UPDATE polls SET votes = ?, updatedAt = ? WHERE id = ?',
+      [JSON.stringify(votes), now, id]
+    );
+  }
+
+  async getLatestPollForTrip(tripId: string): Promise<Poll | null> {
+    if (!this.db) throw new Error('Database not initialized');
+    const res = await this.db.getFirstAsync('SELECT * FROM polls WHERE tripId = ? ORDER BY createdAt DESC LIMIT 1', [tripId]);
+    return res as Poll | null;
+  }
 }
 
 export const databaseService = new DatabaseService();
+
+// Helper types and utilities for budgeting
+export type BookingStatus = 'placeholder' | 'booked' | 'canceled';
+
+export interface SpendByDay {
+  day: number;
+  total: number;
+}
+
+export async function setTripDailyCap(tripId: string, cap: number | null): Promise<void> {
+  await databaseService.updateTrip(tripId, { dailySpendCap: cap } as any);
+}
+
+export async function getSpendForTripDay(tripId: string, day: number): Promise<number> {
+  // Costs stored as TEXT - cast to REAL for summation
+  // If any invalid values exist, they will be treated as 0.0 by CAST
+  const db = (databaseService as any).db as SQLite.SQLiteDatabase | null;
+  if (!db) throw new Error('Database not initialized');
+  const row = await db.getFirstAsync(
+    'SELECT SUM(CAST(cost AS REAL)) as total FROM activities WHERE tripId = ? AND day = ?',
+    [tripId, day]
+  );
+  const total = (row && (row as any).total != null) ? Number((row as any).total) : 0;
+  return total;
+}
+
+export async function getSpendByDayForTrip(tripId: string): Promise<SpendByDay[]> {
+  const db = (databaseService as any).db as SQLite.SQLiteDatabase | null;
+  if (!db) throw new Error('Database not initialized');
+  const rows = await db.getAllAsync(
+    'SELECT day, SUM(CAST(cost AS REAL)) as total FROM activities WHERE tripId = ? GROUP BY day ORDER BY day ASC',
+    [tripId]
+  );
+  return (rows as any[]).map(r => ({ day: Number(r.day), total: Number(r.total || 0) }));
+}

--- a/src/services/ocr.ts
+++ b/src/services/ocr.ts
@@ -1,0 +1,18 @@
+// Mock OCR service: attempt to extract an amount-like number from an image URI
+// In the future, integrate with a real OCR provider (e.g., Google Vision, Tesseract)
+
+export async function extractAmountFromImage(imageUri: string): Promise<number | null> {
+  try {
+    // Mock: parse number that might be in the filename like ..._23.45.jpg
+    const match = imageUri.match(/([0-9]+(?:\.[0-9]{1,2})?)/);
+    if (match) {
+      const num = parseFloat(match[1]);
+      if (Number.isFinite(num)) return Math.round(num * 100) / 100;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+


### PR DESCRIPTION
…lider; remove duplicate visuals

feat(db): add dailySpendCap to trips; add receiptUri, bookingStatus, bookingReminderISO to activities; add spend queries
feat(activities): add receipt upload + mock OCR auto-fill; booking status chips; booking reminder notifications
feat(activities): booking reminder uses DatePicker (time) instead of text input
feat(settings): add currency selector (GBP/USD/EUR) and apply symbol to costs
feat(saved-trips): edit daily spend cap; show cap on card; over‑cap days badge; per‑day spend chips; total trip spend
feat(activities): travel settings modal improvements; day spend vs cap banner when filtered by day
fix(activities): decouple booking status chips; remove duplicated blocks; declutter add form
feat(setup/saved-trips): standardize DatePicker mode=“date” for “When are you traveling?”
refactor(ui): chip labels prevent cutoff; tidy spacing and layout in forms
chore: add currency service (persist via AsyncStorage); helpers for symbols/formatting
chore: replace custom PreferenceSlider with @react-native-community/s…
chore: ios/expo warnings addressed where applicable; minor lint fixes