### PR TITLE
feat: Add dismiss functionality to WeatherWidget

### DIFF
--- a/src/components/WeatherWidget.tsx
+++ b/src/components/WeatherWidget.tsx
@@ -33,9 +33,10 @@ interface WeatherData {
 interface WeatherWidgetProps {
   destination: string;
   onRefresh?: () => void;
+  onDismiss?: () => void;
 }
 
-export const WeatherWidget: React.FC<WeatherWidgetProps> = ({ destination, onRefresh }) => {
+export const WeatherWidget: React.FC<WeatherWidgetProps> = ({ destination, onRefresh, onDismiss }) => {
   const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -276,9 +277,16 @@ export const WeatherWidget: React.FC<WeatherWidgetProps> = ({ destination, onRef
             <Text style={styles.demoText}>DEMO</Text>
           </View>
         )}
-        <TouchableOpacity onPress={fetchWeatherData} style={styles.refreshButton}>
-          <Ionicons name="refresh" size={20} color={colors.primary.main} />
-        </TouchableOpacity>
+        <View style={styles.headerButtons}>
+          <TouchableOpacity onPress={fetchWeatherData} style={styles.refreshButton}>
+            <Ionicons name="refresh" size={20} color={colors.primary.main} />
+          </TouchableOpacity>
+          {onDismiss && (
+            <TouchableOpacity onPress={onDismiss} style={styles.dismissButton}>
+              <Ionicons name="close" size={20} color={colors.text.secondary} />
+            </TouchableOpacity>
+          )}
+        </View>
       </View>
 
       {/* Current Weather */}
@@ -488,5 +496,15 @@ const styles = StyleSheet.create({
     fontFamily: typography?.fontFamily?.bold || 'System',
     color: colors.white,
     fontWeight: '700',
+  },
+  headerButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  dismissButton: {
+    padding: spacing.xs,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.surface.secondary,
   },
 });

--- a/src/screens/EnhancedSavedTripsScreen.tsx
+++ b/src/screens/EnhancedSavedTripsScreen.tsx
@@ -459,7 +459,10 @@ export const EnhancedSavedTripsScreen = () => {
                 <Ionicons name="close" size={24} color={colors.text.primary} />
               </TouchableOpacity>
             </View>
-            <WeatherWidget destination={weatherTrip.destination} />
+            <WeatherWidget 
+              destination={weatherTrip.destination} 
+              onDismiss={() => setWeatherTrip(null)}
+            />
           </View>
         </Modal>
       )}

--- a/src/screens/SavedTripsScreen.tsx
+++ b/src/screens/SavedTripsScreen.tsx
@@ -715,6 +715,7 @@ export const SavedTripsScreen = ({ onNavigateToSetup, onNavigateToItinerary, onO
             <View style={styles.modalContent}>
               <WeatherWidget 
                 destination={weatherTrip?.destination || ''} 
+                onDismiss={handleCloseWeather}
               />
             </View>
           </View>

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -42,6 +42,7 @@ export const SetupScreen = () => {
   const [errors, setErrors] = useState<FormErrors>({});
   const [touched, setTouched] = useState<{ [key: string]: boolean }>({});
   const [isLoading, setIsLoading] = useState(false);
+  const [showWeatherWidget, setShowWeatherWidget] = useState(true);
 
   useEffect(() => { (async () => { try { await databaseService.init(); } catch {} })(); }, []);
 
@@ -287,7 +288,12 @@ export const SetupScreen = () => {
         </Section>
 
         {/* Weather Widget */}
-        <WeatherWidget destination={destination} />
+        {showWeatherWidget && (
+          <WeatherWidget 
+            destination={destination} 
+            onDismiss={() => setShowWeatherWidget(false)}
+          />
+        )}
 
         {/* Currency Converter */}
         <CurrencyConverter destination={destination} />


### PR DESCRIPTION
- Add onDismiss prop to WeatherWidget interface
- Add X button in weather widget header for dismissing
- Update SetupScreen to manage weather widget visibility state
- Update SavedTripsScreen and EnhancedSavedTripsScreen to use dismiss functionality
- Add proper styling for dismiss button and header buttons layout
- Improve user experience with dismissable weather widget

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional dismiss control to `WeatherWidget` and updates screens to handle hiding/closing the widget.
> 
> - **UI Component: `src/components/WeatherWidget.tsx`**
>   - Add optional `onDismiss` prop and render close button in header (`Ionicons: close`).
>   - Wrap header controls in new `headerButtons` container with existing refresh button.
>   - Add styles: `headerButtons`, `dismissButton`.
> - **Screens**
>   - `src/screens/SetupScreen.tsx`: Introduce `showWeatherWidget` state; conditionally render `WeatherWidget` with `onDismiss` to hide it.
>   - `src/screens/SavedTripsScreen.tsx`: Pass `onDismiss={handleCloseWeather}` to modal `WeatherWidget`.
>   - `src/screens/EnhancedSavedTripsScreen.tsx`: Pass `onDismiss` that clears `weatherTrip`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9da783619b68f888d8210ed129d838f89725c471. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->